### PR TITLE
新增容器资源限制功能

### DIFF
--- a/cgroups/CgroupManager.go
+++ b/cgroups/CgroupManager.go
@@ -6,13 +6,17 @@ import (
 )
 
 type CgroupManager struct {
-	// cgroup在hierarchy中的路径 相当于创建的cgroup目录相对于root cgroup目录的路径
+	// cgroup在hierarchy中的路径
+	// 相当于创建的cgroup目录相对于root cgroup目录的路径
 	Path string
+	// 容器的资源限制，一旦创建之后不可修改
+	subsystems.ResourceConfig
 }
 
-func NewCgroupManager(path string) *CgroupManager {
+func NewCgroupManager(path string, res subsystems.ResourceConfig) *CgroupManager {
 	return &CgroupManager{
-		Path: path,
+		Path:           path,
+		ResourceConfig: res,
 	}
 }
 
@@ -25,9 +29,9 @@ func (c *CgroupManager) Apply(pid int) error {
 }
 
 // Set 设置cgroup资源限制
-func (c *CgroupManager) Set(res *subsystems.ResourceConfig) error {
+func (c *CgroupManager) Set() error {
 	for _, subSysIns := range subsystems.SubSystemIns {
-		subSysIns.Set(c.Path, res)
+		subSysIns.Set(c.Path, c.ResourceConfig)
 	}
 	return nil
 }

--- a/cgroups/CgroupManager.go
+++ b/cgroups/CgroupManager.go
@@ -1,0 +1,43 @@
+package cgroups
+
+import (
+	"github.com/sirupsen/logrus"
+	"mini-docker/cgroups/subsystems"
+)
+
+type CgroupManager struct {
+	// cgroup在hierarchy中的路径 相当于创建的cgroup目录相对于root cgroup目录的路径
+	Path string
+}
+
+func NewCgroupManager(path string) *CgroupManager {
+	return &CgroupManager{
+		Path: path,
+	}
+}
+
+// Apply 将进程pid加入到这个cgroup中
+func (c *CgroupManager) Apply(pid int) error {
+	for _, subSysIns := range subsystems.SubSystemIns {
+		subSysIns.Apply(c.Path, pid)
+	}
+	return nil
+}
+
+// Set 设置cgroup资源限制
+func (c *CgroupManager) Set(res *subsystems.ResourceConfig) error {
+	for _, subSysIns := range subsystems.SubSystemIns {
+		subSysIns.Set(c.Path, res)
+	}
+	return nil
+}
+
+// Destroy 释放cgroup
+func (c *CgroupManager) Destroy() error {
+	for _, subSysIns := range subsystems.SubSystemIns {
+		if err := subSysIns.Remove(c.Path); err != nil {
+			logrus.Warnf("remove cgroup fail %v", err)
+		}
+	}
+	return nil
+}

--- a/cgroups/subsystems/CpuSubSystem.go
+++ b/cgroups/subsystems/CpuSubSystem.go
@@ -1,0 +1,47 @@
+package subsystems
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+)
+
+type CpuSubSystem struct {
+}
+
+func (s *CpuSubSystem) Set(cgroupPath string, res *ResourceConfig) error {
+	if subsysCgroupPath, err := GetCgroupPath(s.Name(), cgroupPath, true); err == nil {
+		if res.CpuShare != "" {
+			if err := os.WriteFile(path.Join(subsysCgroupPath, "cpu.shares"), []byte(res.CpuShare), 0644); err != nil {
+				return fmt.Errorf("set cgroup cpu share fail %v", err)
+			}
+		}
+		return nil
+	} else {
+		return err
+	}
+}
+
+func (s *CpuSubSystem) Remove(cgroupPath string) error {
+	if subsysCgroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
+		return os.RemoveAll(subsysCgroupPath)
+	} else {
+		return err
+	}
+}
+
+func (s *CpuSubSystem) Apply(cgroupPath string, pid int) error {
+	if subsysCgroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
+		if err := os.WriteFile(path.Join(subsysCgroupPath, "tasks"), []byte(strconv.Itoa(pid)), 0644); err != nil {
+			return fmt.Errorf("set cgroup proc fail %v", err)
+		}
+		return nil
+	} else {
+		return fmt.Errorf("get cgroup %s error: %v", cgroupPath, err)
+	}
+}
+
+func (s *CpuSubSystem) Name() string {
+	return "cpu"
+}

--- a/cgroups/subsystems/CpuSubSystem.go
+++ b/cgroups/subsystems/CpuSubSystem.go
@@ -10,10 +10,10 @@ import (
 type CpuSubSystem struct {
 }
 
-func (s *CpuSubSystem) Set(cgroupPath string, res *ResourceConfig) error {
-	if subsysCgroupPath, err := GetCgroupPath(s.Name(), cgroupPath, true); err == nil {
+func (s *CpuSubSystem) Set(cgroupPath string, res ResourceConfig) error {
+	if subSystemGroupPath, err := GetCgroupPath(s.Name(), cgroupPath, true); err == nil {
 		if res.CpuShare != "" {
-			if err := os.WriteFile(path.Join(subsysCgroupPath, "cpu.shares"), []byte(res.CpuShare), 0644); err != nil {
+			if err := os.WriteFile(path.Join(subSystemGroupPath, "cpu.shares"), []byte(res.CpuShare), 0644); err != nil {
 				return fmt.Errorf("set cgroup cpu share fail %v", err)
 			}
 		}
@@ -24,16 +24,16 @@ func (s *CpuSubSystem) Set(cgroupPath string, res *ResourceConfig) error {
 }
 
 func (s *CpuSubSystem) Remove(cgroupPath string) error {
-	if subsysCgroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
-		return os.RemoveAll(subsysCgroupPath)
+	if subSystemGroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
+		return os.RemoveAll(subSystemGroupPath)
 	} else {
 		return err
 	}
 }
 
 func (s *CpuSubSystem) Apply(cgroupPath string, pid int) error {
-	if subsysCgroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
-		if err := os.WriteFile(path.Join(subsysCgroupPath, "tasks"), []byte(strconv.Itoa(pid)), 0644); err != nil {
+	if subSystemGroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
+		if err := os.WriteFile(path.Join(subSystemGroupPath, "tasks"), []byte(strconv.Itoa(pid)), 0644); err != nil {
 			return fmt.Errorf("set cgroup proc fail %v", err)
 		}
 		return nil

--- a/cgroups/subsystems/CpusetSubSystem.go
+++ b/cgroups/subsystems/CpusetSubSystem.go
@@ -1,0 +1,47 @@
+package subsystems
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+)
+
+type CpusetSubSystem struct {
+}
+
+func (s *CpusetSubSystem) Set(cgroupPath string, res *ResourceConfig) error {
+	if subsysCgroupPath, err := GetCgroupPath(s.Name(), cgroupPath, true); err == nil {
+		if res.CpuSet != "" {
+			if err := os.WriteFile(path.Join(subsysCgroupPath, "cpuset.cpus"), []byte(res.CpuSet), 0644); err != nil {
+				return fmt.Errorf("set cgroup cpuset fail %v", err)
+			}
+		}
+		return nil
+	} else {
+		return err
+	}
+}
+
+func (s *CpusetSubSystem) Remove(cgroupPath string) error {
+	if subsysCgroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
+		return os.RemoveAll(subsysCgroupPath)
+	} else {
+		return err
+	}
+}
+
+func (s *CpusetSubSystem) Apply(cgroupPath string, pid int) error {
+	if subsysCgroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
+		if err := os.WriteFile(path.Join(subsysCgroupPath, "tasks"), []byte(strconv.Itoa(pid)), 0644); err != nil {
+			return fmt.Errorf("set cgroup proc fail %v", err)
+		}
+		return nil
+	} else {
+		return fmt.Errorf("get cgroup %s error: %v", cgroupPath, err)
+	}
+}
+
+func (s *CpusetSubSystem) Name() string {
+	return "cpuset"
+}

--- a/cgroups/subsystems/CpusetSubSystem.go
+++ b/cgroups/subsystems/CpusetSubSystem.go
@@ -10,10 +10,10 @@ import (
 type CpusetSubSystem struct {
 }
 
-func (s *CpusetSubSystem) Set(cgroupPath string, res *ResourceConfig) error {
-	if subsysCgroupPath, err := GetCgroupPath(s.Name(), cgroupPath, true); err == nil {
+func (s *CpusetSubSystem) Set(cgroupPath string, res ResourceConfig) error {
+	if subSystemGroupPath, err := GetCgroupPath(s.Name(), cgroupPath, true); err == nil {
 		if res.CpuSet != "" {
-			if err := os.WriteFile(path.Join(subsysCgroupPath, "cpuset.cpus"), []byte(res.CpuSet), 0644); err != nil {
+			if err := os.WriteFile(path.Join(subSystemGroupPath, "cpuset.cpus"), []byte(res.CpuSet), 0644); err != nil {
 				return fmt.Errorf("set cgroup cpuset fail %v", err)
 			}
 		}
@@ -24,16 +24,16 @@ func (s *CpusetSubSystem) Set(cgroupPath string, res *ResourceConfig) error {
 }
 
 func (s *CpusetSubSystem) Remove(cgroupPath string) error {
-	if subsysCgroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
-		return os.RemoveAll(subsysCgroupPath)
+	if subSystemGroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
+		return os.RemoveAll(subSystemGroupPath)
 	} else {
 		return err
 	}
 }
 
 func (s *CpusetSubSystem) Apply(cgroupPath string, pid int) error {
-	if subsysCgroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
-		if err := os.WriteFile(path.Join(subsysCgroupPath, "tasks"), []byte(strconv.Itoa(pid)), 0644); err != nil {
+	if subSystemGroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
+		if err := os.WriteFile(path.Join(subSystemGroupPath, "tasks"), []byte(strconv.Itoa(pid)), 0644); err != nil {
 			return fmt.Errorf("set cgroup proc fail %v", err)
 		}
 		return nil

--- a/cgroups/subsystems/MemorySubSystem.go
+++ b/cgroups/subsystems/MemorySubSystem.go
@@ -13,7 +13,7 @@ type MemorySubSystem struct {
 func (s *MemorySubSystem) Name() string {
 	return "memory"
 }
-func (s *MemorySubSystem) Set(cgroupPath string, res *ResourceConfig) error {
+func (s *MemorySubSystem) Set(cgroupPath string, res ResourceConfig) error {
 	if subSystemGroupPath, err := GetCgroupPath(s.Name(), cgroupPath, true); err == nil {
 		if res.MemoryLimit != "" {
 			if err := os.WriteFile(path.Join(subSystemGroupPath, "memory.limit_in_bytes"), []byte(res.MemoryLimit), 0644); err != nil {

--- a/cgroups/subsystems/MemorySubSystem.go
+++ b/cgroups/subsystems/MemorySubSystem.go
@@ -1,0 +1,45 @@
+package subsystems
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+)
+
+type MemorySubSystem struct {
+}
+
+func (s *MemorySubSystem) Name() string {
+	return "memory"
+}
+func (s *MemorySubSystem) Set(cgroupPath string, res *ResourceConfig) error {
+	if subSystemGroupPath, err := GetCgroupPath(s.Name(), cgroupPath, true); err == nil {
+		if res.MemoryLimit != "" {
+			if err := os.WriteFile(path.Join(subSystemGroupPath, "memory.limit_in_bytes"), []byte(res.MemoryLimit), 0644); err != nil {
+				return fmt.Errorf("set cgroup memory fail %v", err)
+			}
+		}
+		return nil
+	} else {
+		return err
+	}
+}
+func (s *MemorySubSystem) Remove(cgroupPath string) error {
+	if subSystemGroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
+		return os.RemoveAll(subSystemGroupPath)
+	} else {
+		return err
+	}
+}
+
+func (s *MemorySubSystem) Apply(cgroupPath string, pid int) error {
+	if subSystemGroupPath, err := GetCgroupPath(s.Name(), cgroupPath, false); err == nil {
+		if err := os.WriteFile(path.Join(subSystemGroupPath, "tasks"), []byte(strconv.Itoa(pid)), 0644); err != nil {
+			return fmt.Errorf("set cgroup proc fail %v", err)
+		}
+		return nil
+	} else {
+		return fmt.Errorf("get cgroup %s error: %v", cgroupPath, err)
+	}
+}

--- a/cgroups/subsystems/subsystem.go
+++ b/cgroups/subsystems/subsystem.go
@@ -1,0 +1,29 @@
+package subsystems
+
+// ResourceConfig 配置资源限制的结构体
+type ResourceConfig struct {
+	MemoryLimit string // 内存限制
+	CpuShare    string // CPU时间片权重
+	CpuSet      string // CPU核心数
+}
+
+// Subsystem 对于Cgroups各个子系统的抽象
+// 将cgroup抽象成path，因为cgroup在hierarchy中的路径，便是虚拟文件系统重的虚拟路径
+type Subsystem interface {
+	// Name 返回subsystem的名字，如cpu/memory
+	Name() string
+	// Set 设置某个cgroup在这个subsystem中的资源限制
+	Set(path string, res *ResourceConfig) error
+	// Apply 将进程添加到某个cgroup中
+	Apply(path string, pid int) error
+	// Remove 移除某个cgroup
+	Remove(path string) error
+}
+
+var (
+	SubSystemIns = []Subsystem{
+		&CpuSubSystem{},
+		&MemorySubSystem{},
+		&CpuSubSystem{},
+	}
+)

--- a/cgroups/subsystems/subsystem.go
+++ b/cgroups/subsystems/subsystem.go
@@ -13,7 +13,7 @@ type Subsystem interface {
 	// Name 返回subsystem的名字，如cpu/memory
 	Name() string
 	// Set 设置某个cgroup在这个subsystem中的资源限制
-	Set(path string, res *ResourceConfig) error
+	Set(path string, res ResourceConfig) error
 	// Apply 将进程添加到某个cgroup中
 	Apply(path string, pid int) error
 	// Remove 移除某个cgroup

--- a/cgroups/subsystems/util.go
+++ b/cgroups/subsystems/util.go
@@ -1,0 +1,53 @@
+package subsystems
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+)
+
+// FindCgroupMountPoint 通过/proc/self/mountinfo找出挂载了某个subsystem的hierarchy cgroup根节点所在的目录
+func FindCgroupMountPoint(subsystem string) (string, error) {
+	f, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		txt := scanner.Text()
+		fields := strings.Split(txt, " ")
+		for _, opt := range strings.Split(fields[len(fields)-1], ",") {
+			if opt == subsystem {
+				return fields[4], nil
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("no match subsystem %s", subsystem)
+}
+
+// GetCgroupPath 得到cgroup在文件系统中的绝对路径
+func GetCgroupPath(subsystem string, cgroupPath string, autoCreate bool) (string, error) {
+	cgroupRoot, err := FindCgroupMountPoint(subsystem)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(path.Join(cgroupRoot, cgroupPath)); err == nil || (autoCreate && os.IsNotExist(err)) {
+		if os.IsNotExist(err) {
+			if err := os.Mkdir(path.Join(cgroupRoot, cgroupPath), 0755); err == nil {
+			} else {
+				return "", fmt.Errorf("error create cgroup %v", err)
+			}
+		}
+		return path.Join(cgroupRoot, cgroupPath), nil
+	} else {
+		return "", fmt.Errorf("cgroup path error %v", err)
+	}
+}

--- a/commands.go
+++ b/commands.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"mini-docker/cgroups/subsystems"
 	"mini-docker/container"
 )
 
@@ -16,6 +17,18 @@ var runCommand = cli.Command{
 		cli.BoolFlag{
 			Name:  "ti",
 			Usage: "enable tty",
+		},
+		cli.StringFlag{
+			Name:  "memory",
+			Usage: "memory limit",
+		},
+		cli.StringFlag{
+			Name:  "cpushare",
+			Usage: "cpu share limit",
+		},
+		cli.StringFlag{
+			Name:  "cpuset",
+			Usage: "cpu set limit",
 		},
 	},
 	/*
@@ -30,7 +43,12 @@ var runCommand = cli.Command{
 		}
 		cmd := ctx.Args().Get(0)
 		tty := ctx.Bool("ti")
-		Run(tty, cmd)
+		resourceConfig := subsystems.ResourceConfig{
+			MemoryLimit: ctx.String("memory"),
+			CpuSet:      ctx.String("cpuset"),
+			CpuShare:    ctx.String("cpushare"),
+		}
+		Run(tty, cmd, resourceConfig)
 		return nil
 	},
 }

--- a/run.go
+++ b/run.go
@@ -2,15 +2,23 @@ package main
 
 import (
 	log "github.com/sirupsen/logrus"
+	"mini-docker/cgroups"
+	"mini-docker/cgroups/subsystems"
 	"mini-docker/container"
 	"os"
 )
 
-func Run(tty bool, cmd string) {
+func Run(tty bool, cmd string, res subsystems.ResourceConfig) {
 	parent := container.NewParentProcess(tty, cmd)
 	if err := parent.Start(); err != nil {
 		log.Error(err)
 	}
+
+	manager := cgroups.NewCgroupManager("mini-docker-cgroup", res)
+	manager.Set()
+	manager.Apply(parent.Process.Pid)
+	defer manager.Destroy()
+
 	parent.Wait()
 	os.Exit(-1)
 }


### PR DESCRIPTION
1. 使用cgroup技术对容器的资源进行限制；
2. 改造run命令，添加memory/cpuset/cpushare参数，在容器启动时创建各个cgroup的子系统，并且按照参数进行资源限制，把主进程加入cgroups的tasks中。